### PR TITLE
Update @ts-common/commonmark-to-markdown to fix security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -395,14 +395,21 @@
       }
     },
     "@ts-common/commonmark-to-markdown": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ts-common/commonmark-to-markdown/-/commonmark-to-markdown-1.2.0.tgz",
-      "integrity": "sha512-xFWpGZN1XzWN0egRs6gcT+tgYYw57us/Xr9euoaTsi9N+UR9ZxnG8Mrt4K/KlB54dNIED/LaGxReqRM5L7tKZA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ts-common/commonmark-to-markdown/-/commonmark-to-markdown-2.0.1.tgz",
+      "integrity": "sha512-MZFC3Gu6du09kpoYEVVtCFhUvSA2Am4U7lO+MkgOXb6OLjSnwxoRnvwX3U9T+bJI476/Uwt+fWhGFQ3vCnXpPg==",
       "requires": {
-        "@ts-common/iterator": "^0.3.0",
+        "@ts-common/iterator": "^1.1.0",
         "@types/commonmark": "^0.27.3",
         "commonmark": "^0.28.1",
-        "front-matter": "^3.0.1"
+        "front-matter": "^4.0.2"
+      },
+      "dependencies": {
+        "@ts-common/iterator": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@ts-common/iterator/-/iterator-1.1.0.tgz",
+          "integrity": "sha512-pP7Ee7c54XiLyD2twIQtUGId4ln3w/HxBT207Aq+n4RMq7lGqHt97zKBYlsGawPTuF2z2ZoYiC9l1Wx2lMVpRA=="
+        }
       }
     },
     "@ts-common/fs": {
@@ -1702,9 +1709,9 @@
       }
     },
     "front-matter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-3.1.0.tgz",
-      "integrity": "sha512-RFEK8N6waWTdwBZOPNEtvwMjZ/hUfpwXkYUYkmmOhQGdhSulXhWrFwiUhdhkduLDiIwbROl/faF1X/PC/GGRMw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
       "requires": {
         "js-yaml": "^3.13.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/openapi-markdown",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -395,20 +395,20 @@
       }
     },
     "@ts-common/commonmark-to-markdown": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ts-common/commonmark-to-markdown/-/commonmark-to-markdown-2.0.1.tgz",
-      "integrity": "sha512-MZFC3Gu6du09kpoYEVVtCFhUvSA2Am4U7lO+MkgOXb6OLjSnwxoRnvwX3U9T+bJI476/Uwt+fWhGFQ3vCnXpPg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@ts-common/commonmark-to-markdown/-/commonmark-to-markdown-2.0.2.tgz",
+      "integrity": "sha512-gLUxc7phOvWiDavHDshU3JGxKsepSCYAuXpMVxU0j6MDah2EbV3y0UA4x1wHkWmlf7bVuDLcnsiYQttqEX1zQw==",
       "requires": {
-        "@ts-common/iterator": "^1.1.0",
+        "@ts-common/iterator": "^1.1.1",
         "@types/commonmark": "^0.27.3",
         "commonmark": "^0.28.1",
         "front-matter": "^4.0.2"
       },
       "dependencies": {
         "@ts-common/iterator": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@ts-common/iterator/-/iterator-1.1.0.tgz",
-          "integrity": "sha512-pP7Ee7c54XiLyD2twIQtUGId4ln3w/HxBT207Aq+n4RMq7lGqHt97zKBYlsGawPTuF2z2ZoYiC9l1Wx2lMVpRA=="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@ts-common/iterator/-/iterator-1.1.1.tgz",
+          "integrity": "sha512-1WbfRxKqIeheLDD44S4SV9kAcXuVxc5dfcBlC7Abjeyk9GsWX/Xe2fqgKs6ZN3ySSgMDxhIT1SAHFA4oZeR4eA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/openapi-markdown",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Azure OpenAPI MarkDown",
   "scripts": {
     "tsc": "tsc",
@@ -95,7 +95,7 @@
     "output": "test-results.xml"
   },
   "dependencies": {
-    "@ts-common/commonmark-to-markdown": "^1.2.0",
+    "@ts-common/commonmark-to-markdown": "^2.0.1",
     "@ts-common/virtual-fs": "^0.3.0",
     "@ts-common/string-map": "^0.3.0",
     "@ts-common/iterator": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -95,10 +95,10 @@
     "output": "test-results.xml"
   },
   "dependencies": {
-    "@ts-common/commonmark-to-markdown": "^2.0.1",
-    "@ts-common/virtual-fs": "^0.3.0",
-    "@ts-common/string-map": "^0.3.0",
+    "@ts-common/commonmark-to-markdown": "^2.0.2",
     "@ts-common/iterator": "^0.3.1",
+    "@ts-common/string-map": "^0.3.0",
+    "@ts-common/virtual-fs": "^0.3.0",
     "commonmark": "^0.28.1",
     "js-yaml": "^3.13.1",
     "tslib": "^1.9.3"


### PR DESCRIPTION
Details
Update @ts-common/commonmark-to-markdown from 1.2.0 to 2.0.1